### PR TITLE
Make NewLog public

### DIFF
--- a/log.go
+++ b/log.go
@@ -49,7 +49,7 @@ type Log struct {
 	Events     []*Event        // The list of events in the log
 }
 
-func newLog(event0 *Event) (*Log, []EFISpecIdEventAlgorithmSize) {
+func NewLog(event0 *Event) (*Log, []EFISpecIdEventAlgorithmSize) {
 	var spec Spec
 	var digestSizes []EFISpecIdEventAlgorithmSize
 
@@ -97,7 +97,7 @@ func NewLogForTesting(events []*Event) *Log {
 		return new(Log)
 	}
 
-	log, _ := newLog(events[0])
+	log, _ := NewLog(events[0])
 	log.Events = append(log.Events, events[1:]...)
 	return log
 }

--- a/logreader.go
+++ b/logreader.go
@@ -28,7 +28,7 @@ func ReadLog(r io.Reader, options *LogOptions) (*Log, error) {
 		return nil, err
 	}
 
-	log, digestSizes := newLog(event)
+	log, digestSizes := NewLog(event)
 
 	for {
 		var event *Event


### PR DESCRIPTION
EVE project https://github.com/lf-edge/eve uses this library to create custom TPM event log for remote attestation
Currently NewLog method is private and we need it to be public in order to not only read binary logs but also to be able to create one for custom measurements 
