### PR TITLE
Remove digest validation

### DIFF
--- a/event.go
+++ b/event.go
@@ -203,12 +203,6 @@ func ReadEventCryptoAgile(r io.Reader, digestSizes []EFISpecIdEventAlgorithmSize
 		digests[algorithmId] = digest
 	}
 
-	for _, s := range digestSizes {
-		if _, exists := digests[s.AlgorithmId]; !exists {
-			return nil, fmt.Errorf("event is missing a digest value for algorithm %v", s.AlgorithmId)
-		}
-	}
-
 	for alg, _ := range digests {
 		if alg.IsValid() {
 			continue


### PR DESCRIPTION
Removes the validation requiring an event to contain digests for all algorithms as provided by the TCG_EfiSpecIDEvent.

The only thing I can find in the TPM specification is this:

> The TCG_EfiSpecIDEvent{} structure contains one or more
> TCG_Efi_SpecIdEventAlgorithmSize structures. These contain the algorithmID and
> digestSize for the measurement algorithms used by firmware. As consumers of the event
> log may not recognize the algorithmID, the digestSize field allows a parser to consume
> the events in the log without knowing the implicit size of the algorithm defined by the
> algorithmID.

This leads me to believe that this validation is not required by the spec, and it causes otherwise valid TCG logs (such as those produced by Windows) to not be parsed correctly.

There is already code to abort in case an unknown algorithm is encountered, which to me seems like the important part to guard against.